### PR TITLE
feat: add nixos module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,45 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1741352980,
+        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "mmsg": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1742777868,
+        "narHash": "sha256-MdHiygQjBoM22LUJSjeW87t7eDkfRLI2F4Nd64xdLX4=",
+        "owner": "DreamMaoMao",
+        "repo": "mmsg",
+        "rev": "6c9dc91e86a0eb89db3ef8f8290530441cb7b658",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DreamMaoMao",
+        "repo": "mmsg",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1740019556,
@@ -46,9 +85,25 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/072a6db25e947df2f31aab9eccd0ab75d5b2da11.tar.gz"
       }
     },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1740877520,
+        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
+        "mmsg": "mmsg",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,10 +6,15 @@
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    mmsg = {
+      url = "github:DreamMaoMao/mmsg";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
     {
+      self,
       flake-parts,
       treefmt-nix,
       ...
@@ -19,7 +24,10 @@
         inputs.flake-parts.flakeModules.easyOverlay
       ];
 
-      flake.hmModules.maomaowm = import ./nix/hm-modules.nix;
+      flake = {
+        hmModules.maomaowm = import ./nix/hm-modules.nix;
+        nixosModules.maomaowm = import ./nix/nixos-modules.nix { inherit inputs self; };
+      };
 
       perSystem =
         {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -49,6 +49,10 @@ stdenv.mkDerivation {
       xwayland
     ];
 
+  passthru = {
+    providedSessions = [ "maomao" ];
+  };
+
   meta = {
     mainProgram = "maomao";
     description = "A streamlined but feature-rich Wayland compositor";

--- a/nix/nixos-modules.nix
+++ b/nix/nixos-modules.nix
@@ -1,0 +1,68 @@
+{ inputs, self }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.maomaowm;
+  mmsg = lib.types.submodule {
+    options = {
+      enable = lib.mkEnableOption "Enable mmsg, the ipc for maomaowm";
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = inputs.mmsg.packages.${pkgs.system}.mmsg;
+        description = "The mmsg package to use";
+      };
+    };
+  };
+in
+{
+  options = {
+    programs.maomaowm = {
+      enable = lib.mkEnableOption "maomaowm, a wayland compositor based on dwl";
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = self.packages.${pkgs.system}.maomaowm;
+        description = "The maomaowm package to use";
+      };
+      mmsg = lib.mkOption {
+        type = mmsg;
+        default = {
+          enable = true;
+        };
+        description = "Options for mmsg, the ipc for maomaowm";
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      environment.systemPackages = [ cfg.package ];
+
+      xdg.portal = {
+        enable = lib.mkDefault true;
+
+        wlr.enable = lib.mkDefault true;
+
+        configPackages = [ cfg.package ];
+      };
+
+      security.polkit.enable = lib.mkDefault true;
+
+      programs.xwayland.enable = lib.mkDefault true;
+
+      services = {
+        displayManager.sessionPackages = [ cfg.package ];
+
+        graphical-desktop.enable = lib.mkDefault true;
+      };
+
+    })
+
+    (lib.mkIf cfg.mmsg.enable {
+      environment.systemPackages = [ cfg.mmsg.package ];
+    })
+  ];
+}


### PR DESCRIPTION
Added a nixos module for maomaowm.

When the module is enabled (`programs.maomaowm.enable = true`), maomaowm will be installed, and necessary configuration (e.g. display manager, xdg portal) will be configured. `mmsg` will also be installed as `programs.maomaowm.mmsg` is enabled by default.

I'll write documentation for this after your review.
- [ ] write documentation