### PR TITLE
feat: create virtual monitor in dispatch

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -525,6 +525,10 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
     (*arg).ui = 1 << (atoi(arg_value2) - 1);
   } else if (strcmp(func_name, "quit") == 0) {
     func = quit;
+  } else if (strcmp(func_name, "create_virtual_output") == 0) {
+    func = create_virtual_output;
+  } else if (strcmp(func_name, "destroy_all_virtual_output") == 0) {
+    func = destroy_all_virtual_output;
   } else if (strcmp(func_name, "moveresize") == 0) {
     func = moveresize;
     (*arg).ui = parse_mouse_action(arg_value);

--- a/src/dispatch/dispatch.h
+++ b/src/dispatch/dispatch.h
@@ -55,3 +55,5 @@ void movewin(const Arg *arg);
 void resizewin(const Arg *arg);
 void toggle_named_scratch(const Arg *arg);
 void toggle_render_border(const Arg *arg);
+void create_virtual_output(const Arg *arg);
+void destroy_all_virtual_output(const Arg *arg);


### PR DESCRIPTION
Support the creation of virtual displays to enable the display screens of other devices to be used as extended screens for maomao.

for example use in [Sunshine](https://github.com/LizardByte/Sunshine)

virmon-toggle.sh
```bash
#!/bin/bash

# Function to find the first HEADLESS-* display
find_headless_display() {
    wlr-randr --json | jq -r '.[] | select(.name | startswith("HEADLESS-")) | .name' | head -n 1
}

# Get the first HEADLESS display
HEADLESS_DISPLAY=$(find_headless_display)

if [ -z "$HEADLESS_DISPLAY" ]; then
    mmsg -d create_virtual_output
    notify-send "Creating virtual monitor"
    HEADLESS_DISPLAY=$(find_headless_display)
    wlr-randr --output "$HEADLESS_DISPLAY" --pos 1921,0 --scale 1 --custom-mode 1920x1080@60Hz --on
    wlr-randr --output eDP-1 --pos 0,0 --scale 1 
    notify-send "Starting sunshine"
    sunshine &
    notify-send "Sunshine on"
    exit 0
fi

# Now check and toggle status
enable=$(wlr-randr --json | jq --arg name "$HEADLESS_DISPLAY" '.[] | select(.name == $name) | .enabled')
if [ "$enable" == "true" ]; then
    wlr-randr --output "$HEADLESS_DISPLAY" --off
    pkill sunshine
    notify-send "Sunshine off"
    mmsg -d destroy_all_virtual_output
    notify-send "Removed virtual monitor"
    wlr-randr --output eDP-1 --pos 0,0 --scale 1
else
    wlr-randr --output "$HEADLESS_DISPLAY" --on
    sunshine &
    notify-send "Sunshine on"
fi

```
