### PR TITLE
feat: more complete config parse

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -1354,7 +1354,7 @@ if (parsed == 8) {
       config->axis_bindings_count++;
     }
 
-  } else if (strncmp(key, "gesturebind", 8) == 0) {
+  } else if (strncmp(key, "gesturebind", 11) == 0) {
     config->gesture_bindings =
         realloc(config->gesture_bindings,
                 (config->gesture_bindings_count + 1) * sizeof(GestureBinding));


### PR DESCRIPTION
1. allow `source ` keyword to load other config
```conf
source=~/.config/maomao/env.conf
source=~/.config/maomao/bind.conf
source=~/.config/maomao/rule.conf
```

2.allow space between filed
```conf
hotarea_size = 10
axisbind = shift+super  ,UP , exchange_client , left
env = QT_WAYLAND_FORCE_DPI , 140
...
```