### PR TITLE
feat: optimize named scratchpad

### DIFF
--- a/protocols/dwl-ipc-unstable-v2.xml
+++ b/protocols/dwl-ipc-unstable-v2.xml
@@ -174,6 +174,7 @@ I would probably just submit raphi's patchset but I don't think that would be po
       <arg name="arg2" type="string" summary="arg2."/>
       <arg name="arg3" type="string" summary="arg3."/>
       <arg name="arg4" type="string" summary="arg4."/>
+      <arg name="arg5" type="string" summary="arg5."/>
     </request>
 
     <!-- Version 2 -->

--- a/src/dispatch/dispatch.h
+++ b/src/dispatch/dispatch.h
@@ -53,7 +53,7 @@ void togglefakefullscreen(const Arg *arg);
 void toggleoverlay(const Arg *arg);
 void movewin(const Arg *arg);
 void resizewin(const Arg *arg);
-void toggle_named_scratch(const Arg *arg);
+void toggle_named_scratchpad(const Arg *arg);
 void toggle_render_border(const Arg *arg);
 void create_virtual_output(const Arg *arg);
 void destroy_all_virtual_output(const Arg *arg);


### PR DESCRIPTION
change:

windowrule:
```conf
scratch_width -> scratchpad_width
scratch_height -> scratchpad_height
```
bind:
```conf
toggle_named_scratch -> toggle_named_scratchpad
```

feat:
support exec a command when no target window find.

best use case:
When you can't see this window, execute this shortcut key and it will appear. When you can see it, execute it and it will hide, regardless of whether the window has been opened in advance or not

```conf
bind=alt,h,toggle_named_scratchpad,kitty,mao-yazi,1280,800,kitty -T mao-yazi -e yazi
windowrule=isopenscratchpad:1,width:1280,height:800,appid:kitty,title:mao-yazi
```


