### PR TITLE
fix: remove execinfo for musl systems

### DIFF
--- a/src/maomao.c
+++ b/src/maomao.c
@@ -1,7 +1,6 @@
 /*
  * See LICENSE file for copyright and license details.
  */
-#include <execinfo.h>
 #include <getopt.h>
 #include <libinput.h>
 #include <limits.h>


### PR DESCRIPTION
This patch removes `execinfo.h` header from the source, which is not available on musl libc systems. Removing header does not break the compositor and enables musl users  on different linux distributions (Gentoo, Alpine, Void) to run maomao. Tested on amd64 x86_64 Gentoo Linux with musl libc. 