### PR TITLE
refactor: format nix code with alejandra and optimize src path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,14 +13,13 @@
     };
   };
 
-  outputs =
-    {
-      self,
-      flake-parts,
-      treefmt-nix,
-      ...
-    }@inputs:
-    flake-parts.lib.mkFlake { inherit inputs; } {
+  outputs = {
+    self,
+    flake-parts,
+    treefmt-nix,
+    ...
+  } @ inputs:
+    flake-parts.lib.mkFlake {inherit inputs;} {
       imports = [
         inputs.flake-parts.flakeModules.easyOverlay
       ];
@@ -30,37 +29,35 @@
         nixosModules.maomaowm = import ./nix/nixos-modules.nix self;
       };
 
-      perSystem =
-        {
-          config,
-          pkgs,
-          ...
-        }:
-        let
-          inherit (pkgs)
-            callPackage
-            ;
-          maomaowm = callPackage ./nix {
-            inherit (inputs.nixpkgs-wayland.packages.${pkgs.system}) wlroots;
-            inherit (inputs.mmsg.packages.${pkgs.system}) mmsg;
-          };
-          shellOverride = old: {
-            nativeBuildInputs = old.nativeBuildInputs ++ [ ];
-            buildInputs = old.buildInputs ++ [ ];
-          };
-          treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
-        in
-        {
-          packages.default = maomaowm;
-          overlayAttrs = {
-            inherit (config.packages) maomaowm;
-          };
-          packages = {
-            inherit maomaowm;
-          };
-          devShells.default = maomaowm.overrideAttrs shellOverride;
-          formatter = treefmtEval.config.build.wrapper;
+      perSystem = {
+        config,
+        pkgs,
+        ...
+      }: let
+        inherit
+          (pkgs)
+          callPackage
+          ;
+        maomaowm = callPackage ./nix {
+          inherit (inputs.nixpkgs-wayland.packages.${pkgs.system}) wlroots;
+          inherit (inputs.mmsg.packages.${pkgs.system}) mmsg;
         };
-      systems = [ "x86_64-linux" ];
+        shellOverride = old: {
+          nativeBuildInputs = old.nativeBuildInputs ++ [];
+          buildInputs = old.buildInputs ++ [];
+        };
+        treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
+      in {
+        packages.default = maomaowm;
+        overlayAttrs = {
+          inherit (config.packages) maomaowm;
+        };
+        packages = {
+          inherit maomaowm;
+        };
+        devShells.default = maomaowm.overrideAttrs shellOverride;
+        formatter = treefmtEval.config.build.wrapper;
+      };
+      systems = ["x86_64-linux"];
     };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -18,51 +18,53 @@
   ninja,
   wlroots,
   mmsg,
-}:
-let
+}: let
   pname = "maomaowm";
 in
-stdenv.mkDerivation {
-  inherit pname;
-  version = "nightly";
+  stdenv.mkDerivation {
+    inherit pname;
+    version = "nightly";
 
-  src = ../.;
+    src = builtins.path {
+      path = ../.;
+      name = "source";
+    };
 
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-    wayland-scanner
-  ];
-
-  buildInputs =
-    [
-      libinput
-      libxcb
-      libxkbcommon
-      pcre2
-      pixman
-      wayland
-      wayland-protocols
-      wlroots
-    ]
-    ++ lib.optionals enableXWayland [
-      libX11
-      xcbutilwm
-      xwayland
+    nativeBuildInputs = [
+      meson
+      ninja
+      pkg-config
+      wayland-scanner
     ];
 
-  passthru = {
-    providedSessions = [ "maomao" ];
-    inherit mmsg;
-  };
+    buildInputs =
+      [
+        libinput
+        libxcb
+        libxkbcommon
+        pcre2
+        pixman
+        wayland
+        wayland-protocols
+        wlroots
+      ]
+      ++ lib.optionals enableXWayland [
+        libX11
+        xcbutilwm
+        xwayland
+      ];
 
-  meta = {
-    mainProgram = "maomao";
-    description = "A streamlined but feature-rich Wayland compositor";
-    homepage = "https://github.com/DreamMaoMao/maomaowm";
-    license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ ];
-    platforms = lib.platforms.unix;
-  };
-}
+    passthru = {
+      providedSessions = ["maomao"];
+      inherit mmsg;
+    };
+
+    meta = {
+      mainProgram = "maomao";
+      description = "A streamlined but feature-rich Wayland compositor";
+      homepage = "https://github.com/DreamMaoMao/maomaowm";
+      license = lib.licenses.mit;
+      maintainers = [];
+      platforms = lib.platforms.unix;
+    };
+  }

--- a/nix/hm-modules.nix
+++ b/nix/hm-modules.nix
@@ -1,11 +1,9 @@
-self:
-{
+self: {
   lib,
   config,
   pkgs,
   ...
-}:
-let
+}: let
   inherit (self.packages.${pkgs.system}) maomaowm;
   cfg = config.wayland.windowManager.maomaowm;
   variables = lib.concatStringsSep " " cfg.systemd.variables;
@@ -15,8 +13,7 @@ let
     ${lib.optionalString cfg.systemd.enable systemdActivation}
     ${cfg.autostart_sh}
   '';
-in
-{
+in {
   options = {
     wayland.windowManager.maomaowm = with lib; {
       enable = mkOption {
@@ -53,7 +50,7 @@ in
             "XCURSOR_THEME"
             "XCURSOR_SIZE"
           ];
-          example = [ "--all" ];
+          example = ["--all"];
           description = ''
             Environment variables imported into the systemd and D-Bus user environment.
           '';
@@ -95,23 +92,23 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ maomaowm ];
+    home.packages = [maomaowm];
     home.activation =
       lib.optionalAttrs (cfg.autostart_sh != "") {
-        createMaomaoScript = lib.hm.dag.entryAfter [ "clearMaomaoConfig" ] ''
+        createMaomaoScript = lib.hm.dag.entryAfter ["clearMaomaoConfig"] ''
           cat ${autostart_sh} > $HOME/.config/maomao/autostart.sh
           chmod +x $HOME/.config/maomao/autostart.sh
         '';
       }
       // lib.optionalAttrs (cfg.settings != "") {
-        createMaomaoConfig = lib.hm.dag.entryAfter [ "clearMaomaoConfig" ] ''
+        createMaomaoConfig = lib.hm.dag.entryAfter ["clearMaomaoConfig"] ''
           cat > $HOME/.config/maomao/config.conf <<EOF
           ${cfg.settings}
           EOF
         '';
       }
       // {
-        clearMaomaoConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        clearMaomaoConfig = lib.hm.dag.entryAfter ["writeBoundary"] ''
           rm -rf $HOME/.config/maomao
           mkdir -p $HOME/.config/maomao
         '';
@@ -119,12 +116,14 @@ in
     systemd.user.targets.maomao-session = lib.mkIf cfg.systemd.enable {
       Unit = {
         Description = "maomao compositor session";
-        Documentation = [ "man:systemd.special(7)" ];
-        BindsTo = [ "graphical-session.target" ];
-        Wants = [
-          "graphical-session-pre.target"
-        ] ++ lib.optional cfg.systemd.xdgAutostart "xdg-desktop-autostart.target";
-        After = [ "graphical-session-pre.target" ];
+        Documentation = ["man:systemd.special(7)"];
+        BindsTo = ["graphical-session.target"];
+        Wants =
+          [
+            "graphical-session-pre.target"
+          ]
+          ++ lib.optional cfg.systemd.xdgAutostart "xdg-desktop-autostart.target";
+        After = ["graphical-session-pre.target"];
         Before = lib.optional cfg.systemd.xdgAutostart "xdg-desktop-autostart.target";
       };
     };

--- a/nix/nixos-modules.nix
+++ b/nix/nixos-modules.nix
@@ -1,14 +1,11 @@
-self:
-{
+self: {
   config,
   lib,
   pkgs,
   ...
-}:
-let
+}: let
   cfg = config.programs.maomaowm;
-in
-{
+in {
   options = {
     programs.maomaowm = {
       enable = lib.mkEnableOption "maomaowm, a wayland compositor based on dwl";
@@ -21,16 +18,22 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    environment.systemPackages = [
-      cfg.package
-    ] ++ (if (builtins.hasAttr "mmsg" cfg.package) then [ cfg.package.mmsg ] else [ ]);
+    environment.systemPackages =
+      [
+        cfg.package
+      ]
+      ++ (
+        if (builtins.hasAttr "mmsg" cfg.package)
+        then [cfg.package.mmsg]
+        else []
+      );
 
     xdg.portal = {
       enable = lib.mkDefault true;
 
       wlr.enable = lib.mkDefault true;
 
-      configPackages = [ cfg.package ];
+      configPackages = [cfg.package];
     };
 
     security.polkit.enable = lib.mkDefault true;
@@ -38,10 +41,9 @@ in
     programs.xwayland.enable = lib.mkDefault true;
 
     services = {
-      displayManager.sessionPackages = [ cfg.package ];
+      displayManager.sessionPackages = [cfg.package];
 
       graphical-desktop.enable = lib.mkDefault true;
     };
-
   };
 }


### PR DESCRIPTION
I applied a fix suggested by nix in `nix/default.nix 29:1` file when running `nix develop`:

```bash
You can make Nix evaluate faster and copy fewer files by replacing `./.` with the `self` flake input, or `builtins.path { path = ./.; name = "source"; }`
```

This should improve evaluation speed and remove this warning when fetching and/or using nix flake. `builtins.path` seems available since `nix 2.26`, so this fix won't cause problems for LTS users.

Also formatted `flake.nix` and `nix` directory with [alejandra](https://github.com/kamadorueda/alejandra) because it is commonly used for flake derivations.

`mmsg` has same warning about `builtins.path` in flake. I can send a PR if needed.