### PR TITLE
feat: update bug_report template and add aarch64 arch to nix flake

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,17 +1,24 @@
 ---
 name: Bug report
-about: Something in dwl isn't working correctly
-title: ''
-labels: 'A: bug'
-assignees: ''
-
+about: Something in maomaowm isn't working correctly
+title: ""
+labels: "A: bug"
+assignees: ""
 ---
 
 ## Info
-dwl version:
+
+<!--Paste maomao version from running "maomao -v"-->
+<!--
+Wlroots library needs to be built from this repository to avoid crashes
+https://github.com/DreamMaoMao/wlroots.git
+-->
+
+maomao version:
 wlroots version:
+
 ## Description
+
 <!--
 Only report bugs that can be reproduced on the main line
-Report patch issues to their respective authors
 -->

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,6 @@
         devShells.default = maomaowm.overrideAttrs shellOverride;
         formatter = treefmtEval.config.build.wrapper;
       };
-      systems = ["x86_64-linux"];
+      systems = ["x86_64-linux" "aarch64-linux"];
     };
 }


### PR DESCRIPTION
Maomao compiles for the aarch64 with no issues, and aarch64 is supported in Nix/NixOS.

The result binary: 
```bash
result/bin/maomao: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /nix/store/9vp8z5dhmc194hdf88znglif3wir7i1v-glibc-2.40-66/lib/ld-linux-aarch64.so.1, for GNU/Linux 3.10.0, not stripped
```

Also updated bug report template, since it referenced dwl and dwl patches