### PR TITLE
nix: fix not building

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "flake-compat": {
-      "locked": {
-        "lastModified": 1746162366,
-        "narHash": "sha256-5SSSZ/oQkwfcAz/o/6TlejlVGqeK08wyREBQ5qFFPhM=",
-        "owner": "nix-community",
-        "repo": "flake-compat",
-        "rev": "0f158086a2ecdbb138cd0429410e44994f1b7e4b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -48,43 +33,6 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "lib-aggregate": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs-lib": "nixpkgs-lib_3"
-      },
-      "locked": {
-        "lastModified": 1749989692,
-        "narHash": "sha256-ojISk2CXljR3qIgwgZh4iNzP3W2H3zGH49xWTJARkoM=",
-        "owner": "nix-community",
-        "repo": "lib-aggregate",
-        "rev": "cae85629e70ce05b968757f3af8f2f2b3923d080",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "lib-aggregate",
         "type": "github"
       }
     },
@@ -155,77 +103,31 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_3": {
-      "locked": {
-        "lastModified": 1749950217,
-        "narHash": "sha256-qXoEFKOnznVvMAKezJhSXzRKsJ/LHLRY8NCw1mGhwrU=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "753176a8605439613fc6dc9911267b9f720a2615",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-wayland": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "lib-aggregate": "lib-aggregate",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1750512508,
-        "narHash": "sha256-gqSQsdLwfEXG076aSG/SLxKwmFzPdi6cfpl6OZhfnfo=",
-        "owner": "nix-community",
-        "repo": "nixpkgs-wayland",
-        "rev": "c020c609f5bbf34ad5b39856caabafae6175b739",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs-wayland",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1750365781,
-        "narHash": "sha256-XE/lFNhz5lsriMm/yjXkvSZz5DfvKJLUjsS6pP8EC50=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "08f22084e6085d19bcfb4be30d1ca76ecb96fe54",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "mmsg": "mmsg",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-wayland": "nixpkgs-wayland"
+        "scenefx": "scenefx"
       }
     },
-    "systems": {
+    "scenefx": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "lastModified": 1750744509,
+        "narHash": "sha256-XD5EcquaHBg5spsN06fPHAjVCb1vOMM7oxmjZZ/PxIE=",
+        "owner": "wlrfx",
+        "repo": "scenefx",
+        "rev": "0f069970b410195aa5908d98c6fb41f3f0cd6e76",
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
+        "owner": "wlrfx",
+        "repo": "scenefx",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,13 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixpkgs-wayland.url = "github:nix-community/nixpkgs-wayland";
     flake-parts.url = "github:hercules-ci/flake-parts";
     mmsg = {
       url = "github:DreamMaoMao/mmsg";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    scenefx = {
+      url = "github:wlrfx/scenefx";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -34,8 +37,8 @@
           callPackage
           ;
         maomaowm = callPackage ./nix {
-          inherit (inputs.nixpkgs-wayland.packages.${pkgs.system}) wlroots;
           inherit (inputs.mmsg.packages.${pkgs.system}) mmsg;
+          inherit (inputs.scenefx.packages.${pkgs.system}) scenefx;
         };
         shellOverride = old: {
           nativeBuildInputs = old.nativeBuildInputs ++ [];
@@ -52,6 +55,9 @@
         devShells.default = maomaowm.overrideAttrs shellOverride;
         formatter = pkgs.alejandra;
       };
-      systems = ["x86_64-linux" "aarch64-linux"];
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
     };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,19 +17,35 @@
   enableXWayland ? true,
   meson,
   ninja,
-  wlroots,
   mmsg,
+  libgbm,
+  scenefx,
+  wlroots_0_19,
+  libGL,
 }: let
   pname = "maomaowm";
   # Use patched wlroots from github.com/DreamMaoMao/wlroots
-  wlroots-git = wlroots.overrideAttrs (final: prev: {
-    src = fetchFromGitHub {
-      owner = "DreamMaoMao";
-      repo = "wlroots";
-      rev = "afbb5b7c2b14152730b57aa11119b1b16a299d5b";
-      sha256 = "sha256-pVU+CuiqvduMTpsnDHX/+EWY2qxHX2lXKiVzdGtcnYY=";
-    };
-  });
+  wlroots-git = wlroots_0_19.overrideAttrs (
+    final: prev: {
+      src = fetchFromGitHub {
+        owner = "DreamMaoMao";
+        repo = "wlroots";
+        rev = "afbb5b7c2b14152730b57aa11119b1b16a299d5b";
+        sha256 = "sha256-pVU+CuiqvduMTpsnDHX/+EWY2qxHX2lXKiVzdGtcnYY=";
+      };
+    }
+  );
+  scenefx-0-4 = scenefx.overrideAttrs (
+    final: prev: {
+      buildInputs =
+        prev.buildInputs
+        ++ [
+          libgbm
+          libxcb
+          xcbutilwm
+        ];
+    }
+  );
 in
   stdenv.mkDerivation {
     inherit pname;
@@ -57,6 +73,8 @@ in
         wayland
         wayland-protocols
         wlroots-git
+        scenefx-0-4
+        libGL
       ]
       ++ lib.optionals enableXWayland [
         libX11

--- a/src/config/preset.h
+++ b/src/config/preset.h
@@ -190,14 +190,6 @@ int border_radius_location_default = CORNER_LOCATION_ALL;
 int blur = 0;
 int blur_layer = 0;
 
-struct blur_data {
-	int num_passes;
-	int radius;
-	float noise;
-	float brightness;
-	float contrast;
-	float saturation;
-};
 struct blur_data blur_params;
 
 int blur_params_num_passes = 1;


### PR DESCRIPTION
注意，这个PR把`src/config/preset.h`中对`blur_data`的定义去掉了，因为这个定义缺失的问题在最新的scenefx中被修复了（参见[这个commit](https://github.com/wlrfx/scenefx/commit/123a0f177c7ac9db19acdd4a7fa8188f716f0228)）。在merge之前请更新最新的scenefx，检查一下是否可以正常构建。

Added dependencies like scenefx so that the nix package can build successfully.
Note that the PR also changes `src/config/preset.h`: The `blur_data` struct definition is removed, as it is fixed in the latest version of scenefx (Please check [this commit](https://github.com/wlrfx/scenefx/commit/123a0f177c7ac9db19acdd4a7fa8188f716f0228)).