### PR TITLE
nix: update license

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -79,7 +79,7 @@ in
       mainProgram = "maomao";
       description = "A streamlined but feature-rich Wayland compositor";
       homepage = "https://github.com/DreamMaoMao/maomaowm";
-      license = lib.licenses.mit;
+      license = lib.licenses.gpl3Plus;
       maintainers = [];
       platforms = lib.platforms.unix;
     };


### PR DESCRIPTION
Updates license in `default.nix` to GPL-3.0-or-later, which is mentioned in #127.