### PR TITLE
feat: add libinput scroll_button

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -205,6 +205,7 @@ typedef struct {
 	unsigned int accel_profile;
 	double accel_speed;
 	unsigned int scroll_method;
+	unsigned int scroll_button;
 	unsigned int click_method;
 	unsigned int send_events_mode;
 	unsigned int button_map;
@@ -1170,6 +1171,8 @@ void parse_config_line(Config *config, const char *line) {
 		config->accel_speed = atof(value);
 	} else if (strcmp(key, "scroll_method") == 0) {
 		config->scroll_method = atoi(value);
+	} else if (strcmp(key, "scroll_button") == 0) {
+			config->scroll_button = atoi(value);
 	} else if (strcmp(key, "click_method") == 0) {
 		config->click_method = atoi(value);
 	} else if (strcmp(key, "send_events_mode") == 0) {
@@ -2174,6 +2177,7 @@ void override_config(void) {
 	accel_profile = CLAMP_INT(config.accel_profile, 0, 2);
 	accel_speed = CLAMP_FLOAT(config.accel_speed, -1.0f, 1.0f);
 	scroll_method = CLAMP_INT(config.scroll_method, 0, 4);
+	scroll_button = CLAMP_INT(config.scroll_button, 272, 276);
 	click_method = CLAMP_INT(config.click_method, 0, 2);
 	send_events_mode = CLAMP_INT(config.send_events_mode, 0, 2);
 	button_map = CLAMP_INT(config.button_map, 0, 1);
@@ -2318,6 +2322,7 @@ void set_value_default() {
 	config.accel_profile = accel_profile;
 	config.accel_speed = accel_speed;
 	config.scroll_method = scroll_method;
+	config.scroll_button = scroll_button;
 	config.click_method = click_method;
 	config.send_events_mode = send_events_mode;
 	config.button_map = button_map;

--- a/src/config/preset.h
+++ b/src/config/preset.h
@@ -134,6 +134,7 @@ LIBINPUT_CONFIG_SCROLL_EDGE
 LIBINPUT_CONFIG_SCROLL_ON_BUTTON_DOWN
 */
 enum libinput_config_scroll_method scroll_method = LIBINPUT_CONFIG_SCROLL_2FG;
+unsigned int scroll_button = 274;
 
 /* You can choose between:
 LIBINPUT_CONFIG_CLICK_METHOD_NONE

--- a/src/maomao.c
+++ b/src/maomao.c
@@ -3940,6 +3940,9 @@ void createpointer(struct wlr_pointer *pointer) {
 		if (libinput_device_config_scroll_get_methods(device) !=
 			LIBINPUT_CONFIG_SCROLL_NO_SCROLL)
 			libinput_device_config_scroll_set_method(device, scroll_method);
+		if (libinput_device_config_scroll_get_methods(device) ==
+					LIBINPUT_CONFIG_SCROLL_ON_BUTTON_DOWN)
+					libinput_device_config_scroll_set_button(device, scroll_button);
 
 		if (libinput_device_config_click_get_methods(device) !=
 			LIBINPUT_CONFIG_CLICK_METHOD_NONE)


### PR DESCRIPTION
This MR adds a option to set a button for when scroll_on_button_down is enabled as the scroll method. The user can define a different button to the enable the scroll event. By default the middle mouse button (274) is used, but with the `scroll_button` setting any other mouse button can be set, like the right mouse button (273) or a lateral button like back and forward buttons.