### PR TITLE
Comboview - Use initial tag for layouts

### DIFF
--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1282,19 +1282,19 @@ void viewtoright_have_client(const Arg *arg) {
 
 void comboview(const Arg *arg) {
 	unsigned int newtags = arg->ui & TAGMASK;
-	unsigned int target_tag = selmon->tagset[selmon->seltags];
 
 	if (!newtags || !selmon)
 		return;
 
-	if (tag_combo)
-		target_tag |= newtags;
-	else {
+	if (tag_combo) {
+		selmon->tagset[selmon->seltags] |= newtags;
+		focusclient(focustop(selmon), 1);
+		arrange(selmon, false);
+	} else {
 		tag_combo = true;
-		target_tag = newtags;
+		view(&(Arg){.ui = newtags}, false);
 	}
 
-	view(&(Arg){.ui = target_tag}, false);
 	printstatus();
 }
 


### PR DESCRIPTION
Original implementation would always use tag based on smallest tag in combo. This satisfies letting tags reserve layout for simple switches, but quickly becomes confusing when doing larger combo gestures. This change will have subsequent tags added in the combo work like combowview instead, always retaining the initial tags layout. 


https://github.com/user-attachments/assets/5d8b64dc-2ed9-451d-ac79-fcea3b0c9efe

Demonstrates this behavior. Previous behavior would always use smallest tag in the combo to determine layout. I've done this as a draft as this could be an opinion-related thing. I see this as more intuitive than using the smallest index. It gives more control over layout if you are making use of perTag layouts. 