### PR TITLE
fix: ensure tag changes happen on correct monitor

### DIFF
--- a/src/ext-protocol/foreign-toplevel.h
+++ b/src/ext-protocol/foreign-toplevel.h
@@ -25,7 +25,7 @@ void handle_foreign_activate_request(struct wl_listener *listener, void *data) {
 	}
 
 	target = get_tags_first_tag(c->tags);
-	view(&(Arg){.ui = target}, true);
+	view_in_mon(&(Arg){.ui = target}, true, c->mon, true);
 	focusclient(c, 1);
 	wlr_foreign_toplevel_handle_v1_set_activated(c->foreign_toplevel, true);
 }

--- a/src/mango.c
+++ b/src/mango.c
@@ -5395,7 +5395,7 @@ urgent(struct wl_listener *listener, void *data) {
 
 	if (focus_on_activate && !c->istagsilent && c != selmon->sel) {
 		if (!(c->mon == selmon && c->tags & c->mon->tagset[c->mon->seltags]))
-			view(&(Arg){.ui = c->tags}, true);
+			view_in_mon(&(Arg){.ui = c->tags}, true, c->mon, true);
 		focusclient(c, 1);
 	} else if (c != focustop(selmon)) {
 		if (client_surface(c)->mapped)
@@ -5542,7 +5542,7 @@ void activatex11(struct wl_listener *listener, void *data) {
 
 	if (focus_on_activate && !c->istagsilent && c != selmon->sel) {
 		if (!(c->mon == selmon && c->tags & c->mon->tagset[c->mon->seltags]))
-			view(&(Arg){.ui = c->tags}, true);
+			view_in_mon(&(Arg){.ui = c->tags}, true, c->mon, true);
 		wlr_xwayland_surface_activate(c->surface.xwayland, 1);
 		focusclient(c, 1);
 		need_arrange = true;


### PR DESCRIPTION
Fixes a bug where an activation request from a client on an inactive monitor would change the tag on the currently focused monitor, instead of the client's monitor. This was caused by the tag being changed before the monitor focus was updated to the client's one.