### PR TITLE
feat: allow to build using Guix

### DIFF
--- a/mangowc.scm
+++ b/mangowc.scm
@@ -38,11 +38,9 @@
               (substitute* "meson.build"
                 (("'-DSYSCONFDIR=\\\"@0@\\\"'.format\\('/etc'\\)")
                  "'-DSYSCONFDIR=\"@0@\"'.format(sysconfdir)")
-
                 (("sysconfdir = sysconfdir.substring\\(prefix.length\\(\\)\\)")
                  "")))))))
     (inputs (list wayland
-                  wayland-protocols
                   libinput
                   libdrm
                   libxkbcommon
@@ -56,7 +54,7 @@
                   xcb-util-wm
                   wlroots
                   scenefx))
-    (native-inputs (list meson ninja pkg-config))
+    (native-inputs (list pkg-config wayland-protocols))
     (home-page "https://github.com/DreamMaoMao/mangowc")
     (synopsis "Wayland compositor based on wlroots and scenefx")
     (description "A Wayland compositor based on wlroots and scenefx,


### PR DESCRIPTION
I added a `mangowc.scm` that allow to build the file using Guix in a reproducible way.

This file would be better hosted on a Guix channel (I sent a patch to GNU Guix channel and my personal channel) but I believe it is also nice to have it available directly in the repo.

(I started using it on my personal Guix laptop and it is truely amazing, thank you!).