### PR TITLE
Fix viewcrossmon not respecting Arg.v (target monitor) and cursorwarping

### DIFF
--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1423,7 +1423,10 @@ int viewtoright_have_client(const Arg *arg) {
 }
 
 int viewcrossmon(const Arg *arg) {
-	focusmon(&(Arg){.v = arg->v, .i = UNDIR});
+	// Don't switch monitors if monitor is already focused
+	// This also prevents cursorwarp
+	if (!regex_match(arg->v, selmon->wlr_output->name))
+		focusmon(&(Arg){.v = arg->v, .i = UNDIR});
 	view_in_mon(arg, true, selmon, true);
 	return 0;
 }


### PR DESCRIPTION
`Arg.i` was not set to `UNDIR` which lead to focusmon just focusing the monitor of direction `UP`.

And the cursor would still just warp regardless of whether the target monitor was selected or not