### PR TITLE
nix: fix warning by replacing pkgs.system with pkgs.stdenv.hostPlatfo…

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
       }: let
         inherit (pkgs) callPackage ;
         mango = callPackage ./nix {
-          inherit (inputs.scenefx.packages.${pkgs.system}) scenefx;
+          inherit (inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}) scenefx;
         };
         shellOverride = old: {
           nativeBuildInputs = old.nativeBuildInputs ++ [];

--- a/nix/hm-modules.nix
+++ b/nix/hm-modules.nix
@@ -21,7 +21,7 @@ in {
       };
       package = lib.mkOption {
         type = lib.types.package;
-        default = self.packages.${pkgs.system}.mango;
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.mango;
         description = "The mango package to use";
       };
       systemd = {

--- a/nix/nixos-modules.nix
+++ b/nix/nixos-modules.nix
@@ -11,7 +11,7 @@ in {
       enable = lib.mkEnableOption "mango, a wayland compositor based on dwl";
       package = lib.mkOption {
         type = lib.types.package;
-        default = self.packages.${pkgs.system}.mango;
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.mango;
         description = "The mango package to use";
       };
     };


### PR DESCRIPTION
Fix Nix warning caused by deprecated `pkgs.system`.
Replaced it with `pkgs.stdenv.hostPlatform.system` to match current Nixpkgs convention.