### PR TITLE
fix: nixos example

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,10 @@ Here's an example of using the modules in a flake:
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-parts.url = "github:hercules-ci/flake-parts";
-    mango.url = "github:DreamMaoMao/mango";
+    mango = {
+      url = "github:DreamMaoMao/mango";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
   outputs =
     inputs@{ self, flake-parts, ... }:


### PR DESCRIPTION
I fixed the NixOS example, where `input.nixpkgs.follows = "nixpkgs";` is required to prevent the following error: https://discord.com/channels/1430889676264177687/1430895365460201534/1437716687213559809