### PR TITLE
feat: support transparent wlr session lock

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -339,6 +339,7 @@ typedef struct {
 	int adaptive_sync;
 	int allow_tearing;
 	int allow_shortcuts_inhibit;
+	int transparent_wlr_lock;
 
 	struct xkb_rule_names xkb_rules;
 
@@ -1221,6 +1222,8 @@ void parse_option(Config *config, char *key, char *value) {
 		config->allow_tearing = atoi(value);
 	} else if (strcmp(key, "allow_shortcuts_inhibit") == 0) {
 		config->allow_shortcuts_inhibit = atoi(value);
+	} else if (strcmp(key, "transparent_wlr_lock") == 0) {
+		config->transparent_wlr_lock = atoi(value);
 	} else if (strcmp(key, "no_border_when_single") == 0) {
 		config->no_border_when_single = atoi(value);
 	} else if (strcmp(key, "no_radius_when_single") == 0) {
@@ -2671,6 +2674,7 @@ void override_config(void) {
 	adaptive_sync = CLAMP_INT(config.adaptive_sync, 0, 1);
 	allow_tearing = CLAMP_INT(config.allow_tearing, 0, 2);
 	allow_shortcuts_inhibit = CLAMP_INT(config.allow_shortcuts_inhibit, 0, 1);
+	transparent_wlr_lock = CLAMP_INT(config.transparent_wlr_lock, 0, 1);
 	axis_bind_apply_timeout =
 		CLAMP_INT(config.axis_bind_apply_timeout, 0, 1000);
 	focus_on_activate = CLAMP_INT(config.focus_on_activate, 0, 1);
@@ -2849,6 +2853,7 @@ void set_value_default() {
 	config.adaptive_sync = adaptive_sync;
 	config.allow_tearing = allow_tearing;
 	config.allow_shortcuts_inhibit = allow_shortcuts_inhibit;
+	config.transparent_wlr_lock = transparent_wlr_lock;
 	config.no_border_when_single = no_border_when_single;
 	config.no_radius_when_single = no_radius_when_single;
 	config.snap_distance = snap_distance;

--- a/src/config/preset.h
+++ b/src/config/preset.h
@@ -103,6 +103,7 @@ int warpcursor = 1;			  /* Warp cursor to focused client */
 int xwayland_persistence = 1; /* xwayland persistence */
 int syncobj_enable = 0;
 int adaptive_sync = 0;
+int transparent_wlr_lock = 0;
 double drag_refresh_interval = 30.0;
 int allow_tearing = TEARING_DISABLED;
 int allow_shortcuts_inhibit = SHORTCUTS_INHIBIT_ENABLE;

--- a/src/mango.c
+++ b/src/mango.c
@@ -3029,7 +3029,9 @@ void destroylock(SessionLock *lock, int unlock) {
 	if ((locked = !unlock))
 		goto destroy;
 
-	wlr_scene_node_set_enabled(&locked_bg->node, false);
+	if (locked_bg->node.enabled) {
+		wlr_scene_node_set_enabled(&locked_bg->node, false);
+	}
 
 	focusclient(focustop(selmon), 0);
 	motionnotify(0, NULL, 0, 0, 0, 0);
@@ -3567,7 +3569,9 @@ void pending_kill_client(Client *c) {
 void locksession(struct wl_listener *listener, void *data) {
 	struct wlr_session_lock_v1 *session_lock = data;
 	SessionLock *lock;
-	wlr_scene_node_set_enabled(&locked_bg->node, true);
+	if (!transparent_wlr_lock) {
+		wlr_scene_node_set_enabled(&locked_bg->node, true);
+	}
 	if (cur_lock) {
 		wlr_session_lock_v1_destroy(session_lock);
 		return;


### PR DESCRIPTION
adds an option for enabling transparent wlr session lock surface.
See the following video for comparison.


https://github.com/user-attachments/assets/71c885e3-c2db-432e-a582-cc366f3d639b

> There are a couple frames of BLACK screen before the lockscreen's wallpaper kicks in, with this option enabled we get a seamless transition

hyprland implements the same with `session_lock_xray` option