### PR TITLE
fix: scroller layout window overlap caused by uint

### DIFF
--- a/src/animation/client.h
+++ b/src/animation/client.h
@@ -708,10 +708,10 @@ void client_animation_next_tick(Client *c) {
 		c->animation.initial.height +
 		(c->current.height - c->animation.initial.height) * factor;
 
-	uint32_t x = c->animation.initial.x +
-				 (c->current.x - c->animation.initial.x) * factor;
-	uint32_t y = c->animation.initial.y +
-				 (c->current.y - c->animation.initial.y) * factor;
+	int32_t x = c->animation.initial.x +
+				(c->current.x - c->animation.initial.x) * factor;
+	int32_t y = c->animation.initial.y +
+				(c->current.y - c->animation.initial.y) * factor;
 
 	wlr_scene_node_set_position(&c->scene->node, x, y);
 	c->animation.current = (struct wlr_box){


### PR DESCRIPTION
When windows in scroller layout need to scroll off-screen to the left, they are positioned with negative x coordinates (e.g., `x=-236`). However, the animation code was using `uint32_t`.

The fix changes x and y position variables from `uint32_t` to `int32_t` in `client_animation_next_tick()`, allowing proper handling of negative off-screen coordinates during animation.

this fixes the issue I've commented: https://github.com/DreamMaoMao/mangowc/issues/363#issuecomment-3649847697