### PR TITLE
fix: rounded corners on off-screen window edges

### DIFF
--- a/src/animation/client.h
+++ b/src/animation/client.h
@@ -354,11 +354,13 @@ void apply_border(Client *c) {
 		return;
 
 	bool hit_no_border = check_hit_no_border(c);
-	enum corner_location current_corner_location =
-		c->isfullscreen || (no_radius_when_single && c->mon &&
-							c->mon->visible_tiling_clients == 1)
-			? CORNER_LOCATION_NONE
-			: CORNER_LOCATION_ALL;
+	enum corner_location current_corner_location;
+	if (c->isfullscreen || (no_radius_when_single && c->mon &&
+							c->mon->visible_tiling_clients == 1)) {
+		current_corner_location = CORNER_LOCATION_NONE;
+	} else {
+		current_corner_location = set_client_corner_location(c);
+	}
 
 	// Handle no-border cases
 	if (hit_no_border && smartgaps) {


### PR DESCRIPTION
### Problem
When windows extend beyond the visible display area (particularly in scroller layout where windows scroll off-screen), rounded corners were being drawn on all four sides of the window, including sides that are completely off-screen. 
This creates visual artifacts where rounded corners appear at screen edges where they shouldn't.

<details>
<summary>before</summary>
<img width="326" height="320" alt="20251214_14h50m19s_grim" src="https://github.com/user-attachments/assets/006f3b93-26cf-4987-8b46-ebf7f9e39557" />
<img width="628" height="508" alt="20251214_14h50m02s_grim" src="https://github.com/user-attachments/assets/e4704a9f-f8b8-47bb-adcd-6621bb580382" />
</details>

<details>
<summary>after</summary>
<img width="200" height="266" alt="20251214_15h35m26s_grim" src="https://github.com/user-attachments/assets/5ff59307-1e94-4693-8794-7391878285d9" />
<img width="330" height="312" alt="20251214_15h35m00s_grim" src="https://github.com/user-attachments/assets/fc1eaf74-a446-49fe-8d4c-078a69d1e5f4" />

</details>

**FYI:** there seems to be similar issue with shadows, I wasn't able to fix that one easily.