### PR TITLE
feat: scroller exchange windows naturally

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -833,9 +833,11 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 	} else if (strcmp(func_name, "exchange_client") == 0) {
 		func = exchange_client;
 		(*arg).i = parse_direction(arg_value);
+		(*arg).ui = arg_value2 && arg_value2[0] != '\0' ? atoi(arg_value2) : 0;
 	} else if (strcmp(func_name, "exchange_stack_client") == 0) {
 		func = exchange_stack_client;
 		(*arg).i = parse_circle_direction(arg_value);
+		(*arg).ui = arg_value2 && arg_value2[0] != '\0' ? atoi(arg_value2) : 0;
 	} else if (strcmp(func_name, "toggleglobal") == 0) {
 		func = toggleglobal;
 	} else if (strcmp(func_name, "toggleoverview") == 0) {

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -86,7 +86,7 @@ int exchange_client(const Arg *arg) {
 	if ((c->isfullscreen || c->ismaximizescreen) && !is_scroller_layout(c->mon))
 		return 0;
 
-	exchange_two_client(c, direction_select(arg));
+	exchange_two_client(c, direction_select(arg), arg->ui);
 	return 0;
 }
 
@@ -101,7 +101,7 @@ int exchange_stack_client(const Arg *arg) {
 		tc = get_next_stack_client(c, true);
 	}
 	if (tc)
-		exchange_two_client(c, tc);
+		exchange_two_client(c, tc, arg->ui);
 	return 0;
 }
 

--- a/src/mango.c
+++ b/src/mango.c
@@ -625,7 +625,7 @@ static void motionrelative(struct wl_listener *listener, void *data);
 static void reset_foreign_tolevel(Client *c);
 static void remove_foreign_topleve(Client *c);
 static void add_foreign_topleve(Client *c);
-static void exchange_two_client(Client *c1, Client *c2);
+static void exchange_two_client(Client *c1, Client *c2, uint8_t mode);
 static void outputmgrapply(struct wl_listener *listener, void *data);
 static void outputmgrapplyortest(struct wlr_output_configuration_v1 *config,
 								 int test);
@@ -1862,7 +1862,7 @@ void place_drag_tile_client(Client *c) {
 		closest_client->link.prev->next = &c->link;
 		closest_client->link.prev = &c->link;
 	} else if (closest_client) {
-		exchange_two_client(c, closest_client);
+		exchange_two_client(c, closest_client, 0);
 	}
 	setfloating(c, 0);
 }
@@ -4307,7 +4307,7 @@ void setborder_color(Client *c) {
 	client_set_border_color(c, border_color);
 }
 
-void exchange_two_client(Client *c1, Client *c2) {
+void exchange_two_client(Client *c1, Client *c2, uint8_t mode) {
 
 	Monitor *tmp_mon = NULL;
 	uint32_t tmp_tags;
@@ -4379,7 +4379,7 @@ void exchange_two_client(Client *c1, Client *c2) {
 		focusclient(c1, 0);
 	} else {
 		// For scroller layouts, swap geometry to maintain visual positions
-		if (is_scroller_layout(c1->mon)) {
+		if (mode && is_scroller_layout(c1->mon)) {
 			struct wlr_box tmp_geom = c1->geom;
 			c1->geom = c2->geom;
 			c2->geom = tmp_geom;


### PR DESCRIPTION
currently on scroller layout the window exchange command acts weirdly unexpected compared to other layouts.

<details>
<summary>current</summary>

https://github.com/user-attachments/assets/95afa474-83a3-465a-8382-9cfc9742437f

</details>

<details>
<summary>proposed</summary>

https://github.com/user-attachments/assets/76470b08-88b0-423e-9366-da446b8af813

<details>

**PS:** there are some glitch artifacts appearing in the middle of moved focused window as visible in **proposed** video.