### PR TITLE
nix: include git rev in version to avoid cache issues

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
         inherit (pkgs) callPackage ;
         mango = callPackage ./nix {
           inherit (inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}) scenefx;
+          gitRev = self.shortRev or "dirty";
         };
         shellOverride = old: {
           nativeBuildInputs = old.nativeBuildInputs ++ [];

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -20,10 +20,11 @@
   libGL,
   enableXWayland ? true,
   debug ? false,
+  gitRev ? "unknown",
 }:
 stdenv.mkDerivation {
   pname = "mango";
-  version = "nightly";
+  version = "nightly-${gitRev}";
 
   src = builtins.path {
     path = ../.;


### PR DESCRIPTION
Changes version from "nightly" to "nightly-<gitRev>" so each commit gets a unique derivation hash, forcing rebuilds when flake inputs update.

Probably this wasn't the problem in my case with cache, probably a human error I had, but this change helps navigate different builds better.

<details>
<summary>changes in action</summary>

```sh
$ ll $(which mmsg)                   
lrwxrwxrwx - root  1 Jan  1970  /home/andy/.nix-profile/bin/mmsg -> /nix/store/0p78hh9bsjsb8qb0sxbc6xi0n7j2lfdm-mango-nightly-5245dc4/bin/mmsg
```