### PR TITLE
feat: detect directory in source config

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -1,8 +1,11 @@
 #include <ctype.h>
+#include <dirent.h>
 #include <libgen.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #ifndef SYSCONFDIR
 #define SYSCONFDIR "/etc"
@@ -359,7 +362,10 @@ typedef struct {
 typedef int (*FuncType)(const Arg *);
 Config config;
 
+void resolve_file_path(const char *file_path, char *full_path, size_t size);
 void parse_config_file(Config *config, const char *file_path);
+void parse_config_file_or_dir(Config *config, const char *file_path);
+void parse_config_dir(Config *config, const char *dir_path);
 
 // Helper function to trim whitespace from start and end of a string
 void trim_whitespace(char *str) {
@@ -2310,7 +2316,7 @@ void parse_option(Config *config, char *key, char *value) {
 		}
 
 	} else if (strncmp(key, "source", 6) == 0) {
-		parse_config_file(config, value);
+		parse_config_file_or_dir(config, value);
 	} else {
 		fprintf(stderr, "Error: Unknown key: %s\n", key);
 	}
@@ -2334,43 +2340,12 @@ void parse_config_file(Config *config, const char *file_path) {
 	FILE *file;
 	char full_path[1024];
 
-	if (file_path[0] == '.' && file_path[1] == '/') {
-		// Relative path
-
-		if (cli_config_path) {
-			char *config_path = strdup(cli_config_path);
-			char *config_dir = dirname(config_path);
-			snprintf(full_path, sizeof(full_path), "%s/%s", config_dir,
-					 file_path + 1);
-			free(config_path);
-		} else {
-			const char *home = getenv("HOME");
-			if (!home) {
-				fprintf(stderr, "Error: HOME environment variable not set.\n");
-				return;
-			}
-			snprintf(full_path, sizeof(full_path), "%s/.config/mango/%s", home,
-					 file_path + 1);
-		}
-		file = fopen(full_path, "r");
-
-	} else if (file_path[0] == '~' &&
-			   (file_path[1] == '/' || file_path[1] == '\0')) {
-		// Home directory
-
-		const char *home = getenv("HOME");
-		if (!home) {
-			fprintf(stderr, "Error: HOME environment variable not set.\n");
-			return;
-		}
-		snprintf(full_path, sizeof(full_path), "%s%s", home, file_path + 1);
-		file = fopen(full_path, "r");
-
-	} else {
-		// Absolute path
-		file = fopen(file_path, "r");
+	resolve_file_path(file_path, full_path, sizeof(full_path));
+	if (full_path[0] == '\0') {
+		return;
 	}
 
+	file = fopen(full_path, "r");
 	if (!file) {
 		perror("Error opening file");
 		return;
@@ -2385,6 +2360,112 @@ void parse_config_file(Config *config, const char *file_path) {
 	}
 
 	fclose(file);
+}
+
+void resolve_file_path(const char *file_path, char *full_path, size_t size) {
+	int len;
+
+	if (file_path[0] == '.' && file_path[1] == '/') {
+		// Relative path
+		if (cli_config_path) {
+			char *config_path = strdup(cli_config_path);
+			char *config_dir = dirname(config_path);
+			len = snprintf(full_path, size, "%s/%s", config_dir, file_path + 1);
+			free(config_path);
+			if (len >= size) {
+				fprintf(stderr, "Error: Path too long\n");
+				full_path[0] = '\0';
+				return;
+			}
+		} else {
+			const char *home = getenv("HOME");
+			if (!home) {
+				fprintf(stderr, "Error: HOME environment variable not set.\n");
+				full_path[0] = '\0';
+				return;
+			}
+			len = snprintf(full_path, size, "%s/.config/mango/%s", home,
+						   file_path + 1);
+			if (len >= size) {
+				fprintf(stderr, "Error: Path too long\n");
+				full_path[0] = '\0';
+				return;
+			}
+		}
+	} else if (file_path[0] == '~' &&
+			   (file_path[1] == '/' || file_path[1] == '\0')) {
+		// Home directory
+		const char *home = getenv("HOME");
+		if (!home) {
+			fprintf(stderr, "Error: HOME environment variable not set.\n");
+			full_path[0] = '\0';
+			return;
+		}
+		len = snprintf(full_path, size, "%s%s", home, file_path + 1);
+		if (len >= size) {
+			fprintf(stderr, "Error: Path too long\n");
+			full_path[0] = '\0';
+			return;
+		}
+	} else {
+		// Absolute
+		len = snprintf(full_path, size, "%s", file_path);
+		if (len >= size) {
+			fprintf(stderr, "Error: Path too long\n");
+			full_path[0] = '\0';
+		}
+	}
+}
+
+void parse_config_file_or_dir(Config *config, const char *file_path) {
+	struct stat st;
+	char full_path[1024];
+
+	resolve_file_path(file_path, full_path, sizeof(full_path));
+	if (full_path[0] == '\0') {
+		return;
+	}
+
+	if (stat(full_path, &st) == 0) {
+		if (S_ISDIR(st.st_mode)) {
+			fprintf(stdout, "loading config in directory %s\n", full_path);
+			parse_config_dir(config, full_path);
+		} else {
+			parse_config_file(config, file_path);
+		}
+	}
+}
+
+void parse_config_dir(Config *config, const char *dir_path) {
+	DIR *dir_stream;
+	struct dirent *entry;
+
+	dir_stream = opendir(dir_path);
+	if (!dir_stream) {
+		fprintf(stderr, "Warning: Cannot open directory: %s\n", dir_path);
+		return;
+	}
+
+	while ((entry = readdir(dir_stream)) != NULL) {
+		char *ext = strrchr(entry->d_name, '.');
+		// Skip if no extension or extension isn't ".conf"
+		if (!ext || strcmp(ext, ".conf") != 0) {
+			continue;
+		}
+
+		// Construct full path to the .conf file
+		char config_file_path[2048];
+		int len = snprintf(config_file_path, sizeof(config_file_path), "%s/%s",
+						   dir_path, entry->d_name);
+		if (len >= sizeof(config_file_path)) {
+			fprintf(stderr, "Error: Path too long\n");
+			continue;
+		}
+
+		parse_config_file(config, config_file_path);
+	}
+
+	closedir(dir_stream);
 }
 
 void free_circle_layout(Config *config) {


### PR DESCRIPTION
TLDR - if  `source`  config  value is a directory, then read the files  and process names that end with `.conf` 

** NOTE ** to reviewer, this is a PoC to invoke discussion . I am  open to change implementation  / design.

## Why? 

*  convenience -  managing configuration becomes basic `cp` and `mv` operations. 
*  ascii file sort -- you can use filenames to sort config loading:  10-bind.conf, 20-monitors.conf. 
*  standard unix/linux pattern. Tools like `sudo` , `pam`, `nginx` use this concept 

## Implementation 

* Add  new function `parse_config_file_or_dir`  which uses  `stat` to detect file or directory , call  `parse_config_file` if file or  `parse_config_dir`  if directory 

## Considerations 

- Use  a new dedicated config field `source-dir`  instead of hijacking `source` config 
-  Add default directory location `$HOME/.config/mango/conf.d`  
-  Or just read by default all `*.conf` files in `$HOME/.config/mango

Themes utilities or shells can simply deposit their own files in this default directory.  I use noctalia and when i enabled /configued mango theme , it wrote into my `$HOME/.config/mango/config.conf`  file . I think it is cleaner to utilize a common "conf" directory. 


Again, open to suggestions   