### PR TITLE
Windowrule offset not applying

### DIFF
--- a/src/mango.c
+++ b/src/mango.c
@@ -1380,7 +1380,7 @@ void applyrules(Client *c) {
 		if (r->offsetx || r->offsety || r->width > 0 || r->height > 0) {
 			hit_rule_pos = r->offsetx || r->offsety ? true : false;
 			c->iscustomsize = 1;
-			c->float_geom = setclient_coordinate_center(c, c->float_geom,
+			c->float_geom =  c->geom = setclient_coordinate_center(c, c->float_geom,
 														r->offsetx, r->offsety);
 		}
 		if (c->isfloating) {


### PR DESCRIPTION
Windows with window rules specifying non-zero offsetx or offsety were incorrectly placed at the top-left corner of the screen instead of specified position in config. Offsets (0,0) produced correct centering though. 
To fix that, I modified:
 c->float_geom = setclient_coordinate_center(c, c->float_geom, r->offsetx, r->offsety); 
to
 c->float_geom = c->geom = setclient_coordinate_center(c, c->float_geom, r->offsetx, r->offsety); 

inside the loop of applyrules function.

### Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/29f991cc-a022-4297-bec5-e5d467851fbc" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/cfad4646-5b67-431a-9399-af853666561e" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e5ba474b-b728-4634-9e61-be5330a3e860" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/843704db-8f9f-437a-9892-a78a8e0a9352" />

### After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/444f3f40-ec42-450f-b343-e50b58a372fc" />
