### PR TITLE
fix: undefined behaviour in tagmon and tagcrossmon

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -990,6 +990,7 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 		}
 	} else if (strcmp(func_name, "tagmon") == 0) {
 		func = tagmon;
+        (*arg).ui = 0;
 		(*arg).i = parse_direction(arg_value);
 		(*arg).i2 = atoi(arg_value2);
 		if ((*arg).i == UNDIR) {

--- a/src/dispatch/bind_define.h
+++ b/src/dispatch/bind_define.h
@@ -1068,7 +1068,7 @@ int32_t tagmon(const Arg *arg) {
 	if (!m || !m->wlr_output->enabled)
 		return 0;
 
-	uint32_t newtags = arg->ui ? arg->ui : arg->i2 ? c->tags : 0;
+	uint32_t newtags = arg->ui != 0 ? arg->ui : arg->i2 != 0 ? c->tags : 1;
 	uint32_t target;
 
 	if (c->mon == m) {


### PR DESCRIPTION
This PR corrects a flawed conditional in the `tagmon` dispatcher, and by extension the `tagcrossmon` dispatcher since that one uses the former internally. The dispatcher uses the `ui` and `i2` fields of the Arg struct; the former corresponding to the tag_number argument of `tagcrossmon`, and the latter corresponding to the keeptag argument of `tagmon`. Currently the dispatcher attempts to check if either of the fields are null in order to determine what tag to move the window to. This is obviously incorrect, as not only are neither of the fields ever initialised as null, but when calling `tagmon` directly, `ui` is even left completely uninitialised! This means that the dispatcher will attempt to use garbage memory as tag data, which is textbook undefined behaviour. This is fixed by replacing the null checks with checks for zero, and directly initialising `ui` as 0 in the `tagmon` code path. In addition, the default value of 0 when keeptag is not set seems to break `setmon` when it is passed there later, so I opted to instead make the default the first tag on the target monitor.