### PR TITLE
Fix uninitialised argument fields when calling `mmsg -d`

### DIFF
--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -897,6 +897,12 @@ FuncType parse_func_name(char *func_name, Arg *arg, char *arg_value,
 						 char *arg_value5) {
 
 	FuncType func = NULL;
+    (*arg).i = 0;
+    (*arg).i2 = 0;
+    (*arg).f = 0.0f;
+    (*arg).f2 = 0.0f;
+    (*arg).ui = 0;
+    (*arg).ui2 = 0;
 	(*arg).v = NULL;
 	(*arg).v2 = NULL;
 	(*arg).v3 = NULL;


### PR DESCRIPTION
Follow-up to #624: although a commit was made fixing several locations where argument fields were left uninitialised, one was missed. When calling a dispatcher through IPC using `mmsg`, another code path is taken which still manages to skip initialisation, notably causing undefined behaviour in `tagmon` and `tagcrossmon`. As some fields are already initialised at one point in `parse_func_type`, I feel it is appropriate to ensure the rest are as well there.