### PR TITLE
feat(Dwindle): Hyprland-like dwindle tiling layout.

### DIFF
--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -12,6 +12,7 @@ static void vertical_grid(Monitor *m);
 static void vertical_scroller(Monitor *m);
 static void vertical_deck(Monitor *mon);
 static void tgmix(Monitor *m);
+static void dwindle(Monitor *m);
 
 /* layout(s) */
 Layout overviewlayout = {"󰃇", overview, "overview"};
@@ -29,6 +30,7 @@ enum {
 	VERTICAL_DECK,
 	RIGHT_TILE,
 	TGMIX,
+  DWINDLE,
 };
 
 Layout layouts[] = {
@@ -47,4 +49,5 @@ Layout layouts[] = {
 	{"VG", vertical_grid, "vertical_grid", VERTICAL_GRID}, // 垂直格子布局
 	{"VK", vertical_deck, "vertical_deck", VERTICAL_DECK}, // 垂直卡片布局
 	{"TG", tgmix, "tgmix", TGMIX},						   // 混合布局
+  {"DW", dwindle, "dwindle", DWINDLE},
 };


### PR DESCRIPTION
This PR implements the Dwindle layout, a popular binary tree-based tiling algorithm similar to the one found in Hyprland.

Implemented [dwindle()]: Added the core logic which builds a binary tree from the client list.

Added the `DW` (Dwindle) layout to the registry in 

How it works
- The layout recursively splits the container of the last active window.
- Dynamic Splitting: Checks the aspect ratio of the node to determine whether to split horizontally or vertically (e.g., if `width > height`, it splits side-by-side).
-Gap Support: Fully supports existing gap settings (`gappih`, `gappiv`, center gaps) and smart gaps.

- Verified by switching to the `DW` layout.
- Confirmed that new windows correctly split the available space of the previous window.