### PR TITLE
Add DesktopNames entry to mango.desktop

### DIFF
--- a/mango.desktop
+++ b/mango.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Encoding=UTF-8
 Name=Mango
+DesktopNames=mango;wlroots
 Comment=mango WM
 Exec=mango
 Icon=mango


### PR DESCRIPTION
## feat: add DesktopNames to mango.desktop

### Summary
This Pull Request adds the `DesktopNames` field to the `mango.desktop` file.

### Changes Introduced
The following line is added to `mango.desktop`:
```ini
DesktopNames=mango;wlroots
```

### Motivation
The `DesktopNames` field allows `uwsm` to recognize and launch Mango seamlessly using the `uwsm start mango` command. This helps users quickly launch the compositor and utilize it to its fullest potential, improving the overall experience.

### Testing
- No testing was performed as this is a simple metadata update.