### PR TITLE
fix: -p exits with failure if there are parse failures

### DIFF
--- a/src/mango.c
+++ b/src/mango.c
@@ -6168,8 +6168,7 @@ int32_t main(int32_t argc, char *argv[]) {
 		} else if (c == 'c') {
 			cli_config_path = optarg;
 		} else if (c == 'p') {
-			parse_config();
-			return EXIT_SUCCESS;
+			return parse_config() ? EXIT_SUCCESS : EXIT_FAILURE;
 		} else {
 			goto usage;
 		}


### PR DESCRIPTION
Currently, `-p` always exits with success even if there are config errors. Ideally it should fail on parse errors, so it can be used in a git hook or a checkPhase in nix, which is my intended use case.