### PR TITLE
fix: Warning: Require Meson version >= 0.56.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,6 @@
 project('mango', ['c', 'cpp'],
   version : '0.12.2',
+  meson_version : '>=0.56.0',
 )
 
 subdir('protocols')


### PR DESCRIPTION
fix for the message: 

`Warnning: mangowc-git/protocols/meson.build:3: WARNING: Project does not target a minimum version but uses feature deprecated since '0.56.0': dependency.get_pkgconfig_variable. use dependency.get_variable(pkgconfig : ...) instead`

This is minor but was bothering me.