### PR TITLE
fix warning about meson

### DIFF
--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -1,6 +1,6 @@
 wayland_scanner = find_program('wayland-scanner')
 wayland_protos_dep = dependency('wayland-protocols')
-wl_protocol_dir = wayland_protos_dep.get_pkgconfig_variable('pkgdatadir')
+wl_protocol_dir = wayland_protos_dep.get_variable(pkgconfig:'pkgdatadir')
 wayland_scanner_code = generator(
 	wayland_scanner,
 	output: '@BASENAME@-protocol.c',


### PR DESCRIPTION
fix for the message:

Warnning: mangowc-git/protocols/meson.build:3: WARNING: Project does not target a minimum version but uses feature deprecated since '0.56.0': dependency.get_pkgconfig_variable. use dependency.get_variable(pkgconfig : ...) instead

the previous PR was missing this file.