### PR TITLE
docs: fix guix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ First, add `mangowc` channel to `channels.scm` file:
 (cons (channel
         (name 'mangowc)
         (url "https://github.com/DreamMaoMao/mangowc.git")
-        (branch "main")
+        (branch "main"))
       ... ;; Your other channels
       %default-channels)
 ```


### PR DESCRIPTION
- Rename GuixSD to Guix System (the distro was renamed in 2019)

- Add branch "main" to channel instructions. Without it, Guix tries to find a "master" branch

- Fix declarative installation (not needed if mangowc is installed via "guix install") 
  - change cons to cons*, so it's a list not a pair
  - add missing "-git" to mangowc