### PR TITLE
fix(nix): update deprecated xorg package names to top-level

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -11,7 +11,7 @@
   wayland,
   wayland-protocols,
   wayland-scanner,
-  xcbutilwm,
+  libxcb-wm,
   xwayland,
   meson,
   ninja,
@@ -57,7 +57,7 @@ stdenv.mkDerivation {
     ]
     ++ lib.optionals enableXWayland [
       libX11
-      xcbutilwm
+      libxcb-wm
       xwayland
     ];
 


### PR DESCRIPTION
simple rename xcbutilwm to libxcb-wm
libxcb-wm is already available on nixos stable channel.

This eliminates the deprecation warnings:
- "The xorg package set has been deprecated, 'xorg.xcbutilwm' has been renamed to 'libxcb-wm'"

Changes:
- nix/default.nix:14: xcbutilwm, → libxcb-wm,
- nix/default.nix:60: xcbutilwm → libxcb-wm