### PR TITLE
fix(guix): add deprecated package variable with old naming.

### DIFF
--- a/mangowm.scm
+++ b/mangowm.scm
@@ -61,4 +61,7 @@
 inspired by dwl but aiming to be more feature-rich.")
     (license gpl3)))
 
+(define-deprecated-package mangowc
+  mangowm-git)
+
 mangowm-git


### PR DESCRIPTION
This is required to make old configs still evaluate. Such package rename shouldn't be instant, so for now let's add deprecation notice for mangowc@git:
```
$ guix shell -L. mangowc@git
guix shell: package 'mangowc' has been superseded by 'mangowm'

```