### PR TITLE
chore(sync-website): update commit message

### DIFF
--- a/.github/workflows/sync-website.yml
+++ b/.github/workflows/sync-website.yml
@@ -38,5 +38,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add apps/web/content/docs
-          git diff --staged --quiet || git commit -m "sync from mango @ ${{ github.sha }}"
+          git diff --staged --quiet || git commit \
+            -m "docs: content update from mangowm/mango" \
+            -m "${{ github.event.head_commit.message }}\nSource: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
           git push


### PR DESCRIPTION
Improves the sync commit message in `mangowm/mangowm.github.io` to include the original commit message and a source link for traceability.

**Example:**
```
docs: content update from mangowm/mango

docs: update some describe
Source: https://github.com/mangowm/mango/commit/537e4aa0794a3da4370dc21d02fdf4f16036b3d1
```