### PR TITLE
fix: simplify sync commit message to use source URL only

### DIFF
--- a/.github/workflows/sync-website.yml
+++ b/.github/workflows/sync-website.yml
@@ -40,5 +40,5 @@ jobs:
           git add apps/web/content/docs
           git diff --staged --quiet || git commit \
             -m "docs: content update from mangowm/mango" \
-            -m "${{ github.event.head_commit.message }}\nSource: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
+            -m "${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}"
           git push


### PR DESCRIPTION
before:
```
docs: content update from mangowm/mango
docs: add some note message to monitor rule\nSource: https://github.com/mangowm/mango/commit/14fc6ca99f1eb969f7ec8edac4e836bdd0f736cc
```

after:
```
docs: content update from mangowm/mango
Source: https://github.com/mangowm/mango/commit/14fc6ca99f1eb969f7ec8edac4e836bdd0f736cc
```