### PR TITLE
Add playback section to keys.md

### DIFF
--- a/docs/bindings/keys.md
+++ b/docs/bindings/keys.md
@@ -195,6 +195,16 @@ bind=NONE,XF86AudioMute,spawn,wpctl set-mute @DEFAULT_SINK@ toggle
 bind=SHIFT,XF86AudioMute,spawn,wpctl set-mute @DEFAULT_SOURCE@ toggle
 ```
 
+#### Playback
+
+Requires: `playerctl`
+
+```ini
+bind=NONE,XF86AudioNext,spawn,playerctl next
+bind=NONE,XF86AudioPrev,spawn,playerctl previous
+bind=NONE,XF86AudioPlay,spawn,playerctl play-pause
+```
+
 ### Floating Window Movement
 
 | Command | Param | Description |


### PR DESCRIPTION
Under the "Media Controls" section on "keys.md", add playback keybindings through the Playerctl command-line utility.