### PR TITLE
mmsg: fix -o flag causing empty output when used with -g

### DIFF
--- a/mmsg/mmsg.c
+++ b/mmsg/mmsg.c
@@ -569,12 +569,12 @@ int32_t main(int32_t argc, char *argv[]) {
 		mode = WATCH;
 		break;
 	case 'o':
-		if (mode == SET)
+        if (mode == GET || mode == WATCH)
+            oflag = 1;
+		else if (mode == SET)
 			output_name = EARGF(usage());
 		else
 			output_name = ARGF();
-		if (!output_name)
-			oflag = 1;
 		break;
 	case 't':
 		tflag = 1;


### PR DESCRIPTION
`mmsg` currently does not properly validate whether `-g` has been passed when parsing the `-o` flag. This means that if `-g` is set, and `-o` is not the last flag in the list of arguments, any subsequent flags will still be parsed as an output name, as if `-s` was active. The end result of a target output being set while `-g` also is appears to be that the program simply does nothing and exits. For example, the commands `mmsg -gkot` and `mmsg -g -o -t` both output nothing, while `mmsg -gtko` works as expected.

This PR resolves this by explicitly checking for `-g` when `-o` is encountered.