### PR TITLE
fix: capture windows with subsurfaces

### DIFF
--- a/src/mango.c
+++ b/src/mango.c
@@ -316,7 +316,6 @@ struct Client {
 	struct wlr_scene_tree *image_capture_tree;
 	struct wlr_scene *image_capture_scene;
 	struct wlr_ext_image_capture_source_v1 *image_capture_source;
-	struct wlr_scene_surface *image_capture_scene_surface;
 
 	struct wl_list link;
 	struct wl_list flink;
@@ -4063,8 +4062,9 @@ mapnotify(struct wl_listener *listener, void *data) {
 	c->ext_foreign_toplevel = wlr_ext_foreign_toplevel_handle_v1_create(
 		foreign_toplevel_list, &foreign_toplevel_state);
 	c->ext_foreign_toplevel->data = c;
-	c->image_capture_scene_surface = wlr_scene_surface_create(
-		&c->image_capture_scene->tree, client_surface(c));
+	c->image_capture_tree = c->type == XDGShell
+		? wlr_scene_xdg_surface_create(&c->image_capture_scene->tree, c->surface.xdg)
+		: wlr_scene_subsurface_tree_create(&c->image_capture_scene->tree, client_surface(c));
 
 	/* Handle unmanaged clients first so we can return prior create borders
 	 */
@@ -6110,8 +6110,15 @@ void unmapnotify(struct wl_listener *listener, void *data) {
 		c->swallowing = NULL;
 	}
 
-	wlr_scene_node_destroy(&c->image_capture_scene_surface->buffer->node);
-	wlr_scene_node_destroy(&c->image_capture_scene->tree.node);
+	if (c->image_capture_tree) {
+		wlr_scene_node_destroy(&c->image_capture_tree->node);
+		c->image_capture_tree = NULL;
+	}
+	if (c->image_capture_scene) {
+		wlr_scene_node_destroy(&c->image_capture_scene->tree.node);
+		c->image_capture_scene = NULL;
+	}
+	c->image_capture_source = NULL;
 
 	c->stack_proportion = 0.0f;
 	c->next_in_stack = NULL;


### PR DESCRIPTION
Fix screen capture of applications using wl_subsurface (Firefox, Zen Browser, etc.)

## Problem
wlr_scene_surface_create() only captures the root surface, missing content rendered to subsurfaces. Screen recorders capture only window borders, leaving content blank for affected applications.

## Solution
Create subsurface tree in image_capture_scene:
- wlr_scene_xdg_surface_create() for XDGShell clients
- wlr_scene_subsurface_tree_create() for other types

| Before | After |
|--------|-------|
| <img width="800" alt="without-subsurface" src="https://github.com/user-attachments/assets/b38975f0-2b20-42ad-a8c6-938f30c1dfce" /> | <img width="800" alt="with-subsurface" src="https://github.com/user-attachments/assets/caea8a14-f612-4c41-8b37-09a7c955a859" /> |
