### PR TITLE
fix(xwayland): improve pointer behavior for fullscreen games

### DIFF
--- a/src/mango.c
+++ b/src/mango.c
@@ -4565,6 +4565,16 @@ void pointerfocus(Client *c, struct wlr_surface *surface, double sx, double sy,
 		time = now.tv_sec * 1000 + now.tv_nsec / 1000000;
 	}
 
+#ifdef XWAYLAND
+	if (c && c->mon && client_is_x11(c)) {
+		float scale = c->mon->wlr_output->scale;
+		if (scale > 0.0f && fabsf(scale - 1.0f) > 0.001f) {
+			sx *= scale;
+			sy *= scale;
+		}
+	}
+#endif
+
 	/* Let the client know that the mouse cursor has entered one
 	 * of its surfaces, and make keyboard focus follow if desired.
 	 * wlroots makes this a no-op if surface is already focused */


### PR DESCRIPTION
Description
This PR improves fullscreen behavior for Xwayland games on scaled outputs.
It adjusts pointer coordinates using the output scale before sending pointer enter and motion events to X11 clients.

Why
On HiDPI or fractional scaling, some fullscreen Xwayland games can receive incorrect mouse coordinates, which may cause offset or inconsistent cursor behavior.

Scope

- Applies only to Xwayland clients
- No change for native Wayland clients
- No effect when scale is 1.0

Mostly band-aid, as for some reason some games are not being treated as scale 1.0 even when in togglefullscreen, but this does fix some weird mouse behaviour with those games

Tested:

Marvel Rivals Launcher: Fixes mouse coordinates

Where Winds Meet launcher: Fixes Mouse coordinates

Deadlock: Fixes mouse coordinates in general for Menus

Fixes #807 