### PR TITLE
nix: bump scenefx

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,27 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "scenefx",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1750386251,
@@ -58,21 +79,39 @@
     },
     "scenefx": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1750785057,
-        "narHash": "sha256-tGX6j4W91rcb+glXJo43sjPI9zQvPotonknG1BdihR4=",
+        "lastModified": 1772445487,
+        "narHash": "sha256-dcVDb9mt9DhuLTQPKC1J4f0CdIoGckO7XVf2eJKtN+M=",
         "owner": "wlrfx",
         "repo": "scenefx",
-        "rev": "3a6cfb12e4ba97b43326357d14f7b3e40897adfc",
+        "rev": "bdc3e64ad91b71db725df42095dcc1ea9af49b05",
         "type": "github"
       },
       "original": {
         "owner": "wlrfx",
         "repo": "scenefx",
+        "rev": "bdc3e64ad91b71db725df42095dcc1ea9af49b05",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     scenefx = {
-      url = "github:wlrfx/scenefx";
+      url = "github:wlrfx/scenefx/bdc3e64ad91b71db725df42095dcc1ea9af49b05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -30,7 +30,7 @@
       }: let
         inherit (pkgs) callPackage ;
         mango = callPackage ./nix {
-          inherit (inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}) scenefx;
+          scenefx = inputs.scenefx.packages.${pkgs.stdenv.hostPlatform.system}.default;
         };
         shellOverride = old: {
           nativeBuildInputs = old.nativeBuildInputs ++ [];

--- a/src/animation/client.h
+++ b/src/animation/client.h
@@ -8,25 +8,26 @@ void set_rect_size(struct wlr_scene_rect *rect, int32_t width, int32_t height) {
 	wlr_scene_rect_set_size(rect, GEZERO(width), GEZERO(height));
 }
 
-enum corner_location set_client_corner_location(Client *c) {
-	enum corner_location current_corner_location = CORNER_LOCATION_ALL;
+struct fx_corner_radii set_client_corner_radii(Client *c) {
 	struct wlr_box target_geom =
 		config.animations ? c->animation.current : c->geom;
+	int r = config.border_radius;
+	int tl = r, tr = r, br = r, bl = r;
 	if (target_geom.x + config.border_radius <= c->mon->m.x) {
-		current_corner_location &= ~CORNER_LOCATION_LEFT;
+		tl = 0; bl = 0; // left corners
 	}
 	if (target_geom.x + target_geom.width - config.border_radius >=
 		c->mon->m.x + c->mon->m.width) {
-		current_corner_location &= ~CORNER_LOCATION_RIGHT;
+		tr = 0; br = 0; // right corners
 	}
 	if (target_geom.y + config.border_radius <= c->mon->m.y) {
-		current_corner_location &= ~CORNER_LOCATION_TOP;
+		tl = 0; tr = 0; // top corners
 	}
 	if (target_geom.y + target_geom.height - config.border_radius >=
 		c->mon->m.y + c->mon->m.height) {
-		current_corner_location &= ~CORNER_LOCATION_BOTTOM;
+		bl = 0; br = 0; // bottom corners
 	}
-	return current_corner_location;
+	return corner_radii_new(tl, tr, br, bl);
 }
 
 bool is_horizontal_stack_layout(Monitor *m) {
@@ -226,8 +227,7 @@ void scene_buffer_apply_effect(struct wlr_scene_buffer *buffer, int32_t sx,
 	if (wlr_xdg_popup_try_from_wlr_surface(surface) != NULL)
 		return;
 
-	wlr_scene_buffer_set_corner_radius(buffer, config.border_radius,
-									   buffer_data->corner_location);
+	wlr_scene_buffer_set_corner_radii(buffer, buffer_data->corner_radii);
 }
 
 void buffer_set_effect(Client *c, BufferData data) {
@@ -246,11 +246,20 @@ void buffer_set_effect(Client *c, BufferData data) {
 	if (c->isnoradius || c->isfullscreen ||
 		(config.no_radius_when_single && c->mon &&
 		 c->mon->visible_tiling_clients == 1)) {
-		data.corner_location = CORNER_LOCATION_NONE;
+		data.corner_radii = corner_radii_none();
 	}
 
 	wlr_scene_node_for_each_buffer(&c->scene_surface->node,
 								   scene_buffer_apply_effect, &data);
+
+	if (c->blur) {
+		bool blur_enabled = config.blur && !c->noblur && !c->isfullscreen;
+		wlr_scene_node_set_enabled(&c->blur->node, blur_enabled);
+		if (blur_enabled) {
+			wlr_scene_blur_set_size(c->blur, data.width, data.height);
+			wlr_scene_blur_set_corner_radii(c->blur, data.corner_radii);
+		}
+	}
 }
 
 void client_draw_shadow(Client *c) {
@@ -268,11 +277,11 @@ void client_draw_shadow(Client *c) {
 	}
 
 	bool hit_no_border = check_hit_no_border(c);
-	enum corner_location current_corner_location =
+	struct fx_corner_radii current_corner_radii =
 		c->isfullscreen || (config.no_radius_when_single && c->mon &&
 							c->mon->visible_tiling_clients == 1)
-			? CORNER_LOCATION_NONE
-			: CORNER_LOCATION_ALL;
+			? corner_radii_none()
+			: corner_radii_all(config.border_radius);
 
 	int32_t bwoffset = c->bw != 0 && hit_no_border ? (int32_t)c->bw : 0;
 
@@ -302,8 +311,7 @@ void client_draw_shadow(Client *c) {
 
 	struct clipped_region clipped_region = {
 		.area = intersection_box,
-		.corner_radius = config.border_radius,
-		.corners = current_corner_location,
+		.corners = current_corner_radii,
 	};
 
 	struct wlr_box absolute_shadow_box = {
@@ -355,12 +363,12 @@ void apply_border(Client *c) {
 		return;
 
 	bool hit_no_border = check_hit_no_border(c);
-	enum corner_location current_corner_location;
+	struct fx_corner_radii current_corner_radii;
 	if (c->isfullscreen || (config.no_radius_when_single && c->mon &&
 							c->mon->visible_tiling_clients == 1)) {
-		current_corner_location = CORNER_LOCATION_NONE;
+		current_corner_radii = corner_radii_none();
 	} else {
-		current_corner_location = set_client_corner_location(c);
+		current_corner_radii = set_client_corner_radii(c);
 	}
 
 	if (hit_no_border && config.smartgaps) {
@@ -434,15 +442,13 @@ void apply_border(Client *c) {
 	struct clipped_region clipped_region = {
 		.area = {inner_surface_x, inner_surface_y, inner_surface_width,
 				 inner_surface_height},
-		.corner_radius = config.border_radius,
-		.corners = current_corner_location,
+		.corners = current_corner_radii,
 	};
 
 	wlr_scene_node_set_position(&c->scene_surface->node, c->bw, c->bw);
 	wlr_scene_rect_set_size(c->border, rect_width, rect_height);
 	wlr_scene_node_set_position(&c->border->node, rect_x, rect_y);
-	wlr_scene_rect_set_corner_radius(c->border, config.border_radius,
-									 current_corner_location);
+	wlr_scene_rect_set_corner_radii(c->border, current_corner_radii);
 	wlr_scene_rect_set_clipped_region(c->border, clipped_region);
 }
 
@@ -520,8 +526,8 @@ void client_apply_clip(Client *c, float factor) {
 	struct ivec2 offset;
 	BufferData buffer_data;
 
-	enum corner_location current_corner_location =
-		set_client_corner_location(c);
+	struct fx_corner_radii current_corner_radii =
+		set_client_corner_radii(c);
 
 	if (!config.animations) {
 		c->animation.running = false;
@@ -543,7 +549,7 @@ void client_apply_clip(Client *c, float factor) {
 		wlr_scene_subsurface_tree_set_clip(&c->scene_surface->node, &clip_box);
 		buffer_set_effect(c, (BufferData){1.0f, 1.0f, clip_box.width,
 										  clip_box.height,
-										  current_corner_location, true});
+										  current_corner_radii, true});
 		return;
 	}
 
@@ -600,7 +606,7 @@ void client_apply_clip(Client *c, float factor) {
 	buffer_data.should_scale = true;
 	buffer_data.width = clip_box.width;
 	buffer_data.height = clip_box.height;
-	buffer_data.corner_location = current_corner_location;
+	buffer_data.corner_radii = current_corner_radii;
 
 	if (factor == 1.0) {
 		buffer_data.width_scale = 1.0;

--- a/src/animation/common.h
+++ b/src/animation/common.h
@@ -175,15 +175,8 @@ static bool scene_node_snapshot(struct wlr_scene_node *node, int32_t lx,
 
 		// Effects
 		wlr_scene_buffer_set_opacity(snapshot_buffer, scene_buffer->opacity);
-		wlr_scene_buffer_set_corner_radius(snapshot_buffer,
-										   scene_buffer->corner_radius,
-										   scene_buffer->corners);
-
-		// wlr_scene_buffer_set_backdrop_blur_optimized(
-		// 	snapshot_buffer, scene_buffer->backdrop_blur_optimized);
-		// wlr_scene_buffer_set_backdrop_blur_ignore_transparent(
-		// 	snapshot_buffer, scene_buffer->backdrop_blur_ignore_transparent);
-		wlr_scene_buffer_set_backdrop_blur(snapshot_buffer, false);
+		wlr_scene_buffer_set_corner_radii(snapshot_buffer,
+										  scene_buffer->corners);
 
 		snapshot_buffer->node.data = scene_buffer->node.data;
 
@@ -220,6 +213,8 @@ static bool scene_node_snapshot(struct wlr_scene_node *node, int32_t lx,
 		break;
 	}
 	case WLR_SCENE_NODE_OPTIMIZED_BLUR:
+		return true;
+	case WLR_SCENE_NODE_BLUR:
 		return true;
 	}
 

--- a/src/animation/layer.h
+++ b/src/animation/layer.h
@@ -151,6 +151,24 @@ void set_layer_dir_animaiton(LayerSurface *l, struct wlr_box *geo) {
 	}
 }
 
+void layer_draw_blur(LayerSurface *l) {
+
+	if (!l->mapped || !l->blur)
+		return;
+
+	if (!config.blur || !config.blur_layer || l->noblur) {
+		wlr_scene_node_set_enabled(&l->blur->node, false);
+		return;
+	}
+
+	int32_t width, height;
+	layer_actual_size(l, &width, &height);
+
+	wlr_scene_node_set_enabled(&l->blur->node, true);
+	wlr_scene_blur_set_size(l->blur, width, height);
+	wlr_scene_blur_set_corner_radii(l->blur, config.border_radius_location_default);
+}
+
 void layer_draw_shadow(LayerSurface *l) {
 
 	if (!l->mapped || !l->shadow)
@@ -187,7 +205,6 @@ void layer_draw_shadow(LayerSurface *l) {
 
 	struct clipped_region clipped_region = {
 		.area = intersection_box,
-		.corner_radius = config.border_radius,
 		.corners = config.border_radius_location_default,
 	};
 
@@ -568,8 +585,10 @@ bool layer_draw_frame(LayerSurface *l) {
 		!l->noanim) {
 		layer_animation_next_tick(l);
 		layer_draw_shadow(l);
+		layer_draw_blur(l);
 	} else {
 		layer_draw_shadow(l);
+		layer_draw_blur(l);
 		l->need_output_flush = false;
 	}
 	return true;

--- a/src/config/parse_config.h
+++ b/src/config/parse_config.h
@@ -286,7 +286,7 @@ typedef struct {
 	int32_t blur_layer;
 	int32_t blur_optimized;
 	int32_t border_radius;
-	int32_t border_radius_location_default;
+	struct fx_corner_radii border_radius_location_default;
 	struct blur_data blur_params;
 	int32_t shadows;
 	int32_t shadow_only_floating;
@@ -1384,6 +1384,7 @@ bool parse_option(Config *config, char *key, char *value) {
 		config->blur_optimized = atoi(value);
 	} else if (strcmp(key, "border_radius") == 0) {
 		config->border_radius = atoi(value);
+		config->border_radius_location_default = corner_radii_all(config->border_radius);
 	} else if (strcmp(key, "blur_params_num_passes") == 0) {
 		config->blur_params.num_passes = atoi(value);
 	} else if (strcmp(key, "blur_params_radius") == 0) {
@@ -3363,7 +3364,7 @@ void set_value_default() {
 	config.blur_layer = 0;
 	config.blur_optimized = 1;
 	config.border_radius = 0;
-	config.border_radius_location_default = CORNER_LOCATION_ALL;
+	config.border_radius_location_default = corner_radii_all(config.border_radius);
 	config.blur_params.num_passes = 1;
 	config.blur_params.radius = 5;
 	config.blur_params.noise = 0.02f;

--- a/src/mango.c
+++ b/src/mango.c
@@ -11,7 +11,6 @@
 #include <scenefx/render/fx_renderer/fx_renderer.h>
 #include <scenefx/types/fx/blur_data.h>
 #include <scenefx/types/fx/clipped_region.h>
-#include <scenefx/types/fx/corner_location.h>
 #include <scenefx/types/wlr_scene.h>
 #include <signal.h>
 #include <stdbool.h>
@@ -301,7 +300,7 @@ typedef struct {
 	float height_scale;
 	int32_t width;
 	int32_t height;
-	enum corner_location corner_location;
+	struct fx_corner_radii corner_radii;
 	bool should_scale;
 } BufferData;
 
@@ -315,6 +314,7 @@ struct Client {
 	struct wlr_scene_tree *scene;
 	struct wlr_scene_rect *border; /* top, bottom, left, right */
 	struct wlr_scene_shadow *shadow;
+	struct wlr_scene_blur *blur;
 	struct wlr_scene_tree *scene_surface;
 	struct wl_list link;
 	struct wl_list flink;
@@ -465,6 +465,7 @@ typedef struct {
 	struct wlr_scene_tree *scene;
 	struct wlr_scene_tree *popups;
 	struct wlr_scene_shadow *shadow;
+	struct wlr_scene_blur *blur;
 	struct wlr_scene_layer_surface_v1 *scene_layer;
 	struct wl_list link;
 	struct wl_list fadeout_link;
@@ -763,7 +764,9 @@ static double find_animation_curve_at(double t, int32_t type);
 
 static void apply_opacity_to_rect_nodes(Client *c, struct wlr_scene_node *node,
 										double animation_passed);
-static enum corner_location set_client_corner_location(Client *c);
+static struct fx_corner_radii set_client_corner_radii(Client *c);
+static struct wlr_scene_blur *create_blur_node(struct wlr_scene_tree *parent,
+											   bool enabled);
 static double all_output_frame_duration_ms();
 static struct wlr_scene_tree *
 wlr_scene_tree_snapshot(struct wlr_scene_node *node,
@@ -2391,20 +2394,30 @@ void closemon(Monitor *m) {
 	}
 }
 
-static void iter_layer_scene_buffers(struct wlr_scene_buffer *buffer,
-									 int32_t sx, int32_t sy, void *user_data) {
+static struct wlr_scene_blur *create_blur_node(struct wlr_scene_tree *parent,
+											   bool enabled) {
+	struct wlr_scene_blur *blur = wlr_scene_blur_create(parent, 0, 0);
+	wlr_scene_blur_set_should_only_blur_bottom_layer(blur, true);
+	wlr_scene_node_lower_to_bottom(&blur->node);
+	wlr_scene_node_set_enabled(&blur->node, enabled);
+	return blur;
+}
+
+static void set_blur_mask_source(struct wlr_scene_blur *blur,
+								 struct wlr_scene_buffer *buffer) {
 	struct wlr_scene_surface *scene_surface =
 		wlr_scene_surface_try_from_buffer(buffer);
 	if (!scene_surface) {
 		return;
 	}
+	wlr_scene_blur_set_transparency_mask_source(blur, buffer);
+}
 
-	wlr_scene_buffer_set_backdrop_blur(buffer, true);
-	wlr_scene_buffer_set_backdrop_blur_ignore_transparent(buffer, true);
-	if (config.blur_optimized) {
-		wlr_scene_buffer_set_backdrop_blur_optimized(buffer, true);
-	} else {
-		wlr_scene_buffer_set_backdrop_blur_optimized(buffer, false);
+static void iter_layer_scene_buffers(struct wlr_scene_buffer *buffer,
+									 int32_t sx, int32_t sy, void *user_data) {
+	LayerSurface *l = user_data;
+	if (l->blur) {
+		set_blur_mask_source(l->blur, buffer);
 	}
 }
 
@@ -2443,6 +2456,7 @@ void maplayersurfacenotify(struct wl_listener *listener, void *data) {
 	l->dirty = false;
 	l->noblur = 0;
 	l->shadow = NULL;
+	l->blur = NULL;
 	l->need_output_flush = true;
 
 	// 应用layer规则
@@ -2470,6 +2484,12 @@ void maplayersurfacenotify(struct wl_listener *listener, void *data) {
 									config.shadows_blur, config.shadowscolor);
 		wlr_scene_node_lower_to_bottom(&l->shadow->node);
 		wlr_scene_node_set_enabled(&l->shadow->node, true);
+	}
+
+	if (config.blur && config.blur_layer && !l->noblur &&
+		layer_surface->current.layer != ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM &&
+		layer_surface->current.layer != ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND) {
+		l->blur = create_blur_node(l->scene, true);
 	}
 
 	// 初始化动画
@@ -4018,16 +4038,8 @@ static void iter_xdg_scene_buffers(struct wlr_scene_buffer *buffer, int32_t sx,
 	if (wlr_subsurface_try_from_wlr_surface(surface) != NULL)
 		return;
 
-	if (config.blur && c && !c->noblur) {
-		wlr_scene_buffer_set_backdrop_blur(buffer, true);
-		wlr_scene_buffer_set_backdrop_blur_ignore_transparent(buffer, false);
-		if (config.blur_optimized) {
-			wlr_scene_buffer_set_backdrop_blur_optimized(buffer, true);
-		} else {
-			wlr_scene_buffer_set_backdrop_blur_optimized(buffer, false);
-		}
-	} else {
-		wlr_scene_buffer_set_backdrop_blur(buffer, false);
+	if (config.blur && c && !c->noblur && c->blur) {
+		set_blur_mask_source(c->blur, buffer);
 	}
 }
 
@@ -4177,8 +4189,7 @@ mapnotify(struct wl_listener *listener, void *data) {
 		c->scene, 0, 0, c->isurgent ? config.urgentcolor : config.bordercolor);
 	wlr_scene_node_lower_to_bottom(&c->border->node);
 	wlr_scene_node_set_position(&c->border->node, 0, 0);
-	wlr_scene_rect_set_corner_radius(c->border, config.border_radius,
-									 config.border_radius_location_default);
+	wlr_scene_rect_set_corner_radii(c->border, config.border_radius_location_default);
 	wlr_scene_node_set_enabled(&c->border->node, true);
 
 	c->shadow =
@@ -4187,6 +4198,8 @@ mapnotify(struct wl_listener *listener, void *data) {
 
 	wlr_scene_node_lower_to_bottom(&c->shadow->node);
 	wlr_scene_node_set_enabled(&c->shadow->node, true);
+
+	c->blur = create_blur_node(c->scene, config.blur && !c->noblur);
 
 	if (config.new_is_master && selmon && !is_scroller_layout(selmon))
 		// tile at the top
@@ -6023,6 +6036,10 @@ void unmaplayersurfacenotify(struct wl_listener *listener, void *data) {
 
 	motionnotify(0, NULL, 0, 0, 0, 0);
 	layer_flush_blur_background(l);
+	if (l->blur) {
+		wlr_scene_node_destroy(&l->blur->node);
+		l->blur = NULL;
+	}
 	wlr_scene_node_destroy(&l->shadow->node);
 	l->shadow = NULL;
 	l->being_unmapped = false;


### PR DESCRIPTION
there's currently an evaluation warning:

    evaluation warning: The xorg package set has been deprecated, 'xorg.libxcb' has been renamed to 'libxcb'
    evaluation warning: The xorg package set has been deprecated, 'xorg.xcbutilwm' has been renamed to 'libxcb-wm'

commit wlrfx/scenefx@6291016 updated some package names in line with upstream changes, and bumping that flake will make the warning disappear.

Unfortunately this means we need to deal with a couple of breaking APIs changes:

* the `enum corner_location` and `int corner_radius` pair has been replaced with `struct fx_corner_radii`
* `wlr_scene_buffer_set_backdrop_blur()`, `_ignore_transparent()`, and `_optimized()` have been removed, and  blur is now managed at the scene level via `wlr_scene_blur` nodes

moreover, it appears that https://github.com/wlrfx/scenefx/commit/51d9081 introduced a regression with how transparency is handled, so bump scenefx only to the commit before that (https://github.com/wlrfx/scenefx/commit/bdc3e64) rather than main.

Note that I asked claude for some help with these changes, as I have zero experience with scenefx or wayland. While the first set of changes (`struct fx_corner_radii`) looks reasonable to me, the rest (`wls_scene_blur_*`) probably needs a more thorough look