### PR TITLE
docs: update recommended package name

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -64,7 +64,7 @@ To get a fully functional desktop experience, we recommend installing the follow
 | Terminal Emulator | foot, wezterm, alacritty, kitty, ghostty |
 | Status Bar | waybar, eww, quickshell, ags |
 | Desktop Shell | Noctalia, DankMaterialShell |
-| Wallpaper Setup | swww, swaybg |
+| Wallpaper Setup | awww(swww), swaybg |
 | Notification Daemon | swaync, dunst, mako |
 | Desktop Portal | xdg-desktop-portal, xdg-desktop-portal-wlr, xdg-desktop-portal-gtk |
 | Clipboard | wl-clipboard, wl-clip-persist, cliphist |


### PR DESCRIPTION
The upstream package 'swww' has been renamed to 'awww'.This commit:
- Updates the package name for rolling-release distributions like archlinux
- Keeps 'swww' for other distros that haven't updated yet.